### PR TITLE
Converted set uses, in attributes, to arrays

### DIFF
--- a/src/grammar.js
+++ b/src/grammar.js
@@ -27,15 +27,6 @@ class Grammar {
   }
 
   /**
-   * Converts this regular grammar into a deterministic finite automaton.
-   *
-   * @return {DFA} This regular grammar, converted to an automaton.
-   */
-  toDFA () {
-    throw new Error('TODO')
-  }
-
-  /**
    * Generates a grammar from a non-deterministic finite automaton.
    *
    * @param {NFA} nfa
@@ -43,28 +34,29 @@ class Grammar {
    * @return New Grammar object that represents
    */
   static fromNFA (nfa) {
-    const firstSymbol = nfa.start
+    let firstSymbol = nfa.start
     const productions = {}
-    const aux = new Set()
-    for (let state in nfa.table) {
-      aux.clear()
-      for (let terminalSymbol in nfa.table[state]) {
-        for (let nonTerminalSymbol of nfa.table[state][terminalSymbol]) {
-          aux.add(terminalSymbol + nonTerminalSymbol)
-          if (nfa.accept.has(nonTerminalSymbol)) {
-            aux.add(terminalSymbol)
-          }
+
+    const entries = Object.entries(nfa.table)
+    for (const [state, row] of entries) {
+      const rowEntries = Object.entries(row)
+      productions[state] = []
+      for (const [symbol, states] of rowEntries) {
+        productions[state] = states.map(i => symbol + i)
+        if (states.some(i => nfa.accept.includes(i))) {
+          productions[state].push(symbol)
         }
       }
-      productions[state] = Array.from(aux)
     }
+
     // if language accepts epsilon, add apsilon to the grammar
-    if (nfa.accept.has(nfa.start)) {
-      const newFirstSymbol = firstSymbol + "'"
-      productions[newFirstSymbol] = Array.from(productions[firstSymbol])
-      productions[newFirstSymbol].push('&')
-      return new Grammar(newFirstSymbol, productions)
+    if (nfa.accept.includes(nfa.start)) {
+      const secondSymbol = firstSymbol
+      firstSymbol += "'"
+      productions[firstSymbol] = Array.from(productions[secondSymbol])
+      productions[firstSymbol].push('&')
     }
+
     return new Grammar(firstSymbol, productions)
   }
 

--- a/src/nfa.js
+++ b/src/nfa.js
@@ -699,7 +699,10 @@ class NFA {
    * @return {NFA} returns FA that represents the intersection of dfa with dfb.
    */
   static intersection (dfa, dfb) {
-    return NFA.reverse(NFA.union(NFA.reverse(dfa), NFA.reverse(dfb)))
+    const complementA = NFA.complement(dfa)
+    const complementB = NFA.complement(dfb)
+    const union = NFA.union(complementA, complementB)
+    return NFA.complement(union)
   }
 
   /**
@@ -711,7 +714,8 @@ class NFA {
    * @returns returns FA that represents DFA - DFB
    */
   static diff (dfa, dfb) {
-    return NFA.intersection(dfa, NFA.reverse(dfb))
+    const complementB = NFA.complement(dfb)
+    return NFA.intersection(dfa, complementB)
   }
 
   /**

--- a/src/nfa.js
+++ b/src/nfa.js
@@ -715,24 +715,26 @@ class NFA {
   }
 
   /**
-   * @brief revertes the automata. Everything that was accepted
-   * now is rejected and everything that was rejected now is accepted.
+   * @brief Gets automata that represents the complement of the one passed.
    *
-   * @param {NFA} dfa DFA to be reversed.
+   * @param {NFA} dfa DFA to get the complement.
    *
-   * @return {NFA} reversed DFA.
+   * @return {NFA} Complement of DFA.
    */
-  static reverse (dfa) {
+  static complement (dfa) {
+    // Apply properties
     const reversedDFA = new NFA(dfa.start, dfa.accept, dfa.table)
     reversedDFA.determinize()
     reversedDFA.complete()
-    const newAccept = new Set()
-    Object.keys(reversedDFA.table).forEach(state => {
-      if (!reversedDFA.accept.has(state)) {
-        newAccept.add(state)
-      }
-    })
-    reversedDFA.accept = newAccept
+
+    // Gets states that are not accept states
+    const nonAccept = Object
+      .keys(reversedDFA.table)
+      .filter(i => !reversedDFA.accept.includes(i))
+
+    // Switch
+    reversedDFA.accept = nonAccept
+
     return reversedDFA
   }
 }

--- a/src/nfa.js
+++ b/src/nfa.js
@@ -311,24 +311,49 @@ class NFA {
   }
 
   /**
+   * Checks if the NFA is complete.
+   *
+   * An automata is complete if there is one transition for each symbol of the
+   * alphabet in every state.
+   *
+   * @return {Boolean} True if complete, false otherwise.
+   */
+  isComplete () {
+    const rows = Object.values(this.table)
+    for (const row of rows) {
+      for (const char of this.alphabet) {
+        if (row[char].length === 0) {
+          return false
+        }
+      }
+    }
+
+    return true
+  }
+
+  /**
    * auto completes the missing transitions of automata
    * transitions table.
    */
-  complete () {
-    const newState = 'qdead'
-    let isComplete = true
-    Object.values(this.table).forEach(row => {
-      for (const char of this.alphabet) {
-        if (row[char] === undefined || row[char] === []) {
-          row[char] = new Set([ newState ])
-          isComplete = false
+  complete (errorState = 'qdead') {
+    let errorAdded = false
+
+    // Add error state where it needs to
+    const rows = Object.values(this.table)
+    for (const row of rows) {
+      for (const symbol of this.alphabet) {
+        if (row[symbol].length === 0) {
+          row[symbol] = [ errorState ]
+          errorAdded = true
         }
       }
-    })
-    if (!isComplete) {
-      this.table[newState] = {}
+    }
+
+    // Create error state
+    if (errorAdded) {
+      this.table[errorState] = {}
       for (const char of this.alphabet) {
-        this.table[newState][char] = new Set([ newState ])
+        this.table[errorState][char] = [ errorState ]
       }
     }
   }

--- a/src/nfa.js
+++ b/src/nfa.js
@@ -476,19 +476,16 @@ class NFA {
    */
   static star (fa) {
     const newStart = fa.start
-    const newTable = Object.assign({}, fa.table)
     const newAccept = fa.accept
-    Object.entries(newTable[newStart]).forEach(([char, states]) => {
+    const newTable = Object.assign({}, fa.table)
+
+    const entries = Object.entries(newTable[newStart])
+    for (const [char, states] of entries) {
       for (const acceptState of newAccept) {
-        if (newTable[acceptState][char] === undefined) {
-          newTable[acceptState][char] = states
-        } else {
-          for (const state of states) {
-            newTable[acceptState][char].add(state)
-          }
-        }
+        newTable[acceptState][char].push(...states)
       }
-    })
+    }
+
     return new NFA(newStart, newAccept, newTable)
   }
 

--- a/src/nfa.js
+++ b/src/nfa.js
@@ -723,14 +723,12 @@ class NFA {
    *
    * @return {NFA} dfa minimized.
    */
-  static minimize (dfa) {
-    const minimal = new NFA(dfa.start, dfa.accept, dfa.table)
-    minimal.determinize()
-    minimal.removeUnreachable()
-    minimal.removeDead()
-    minimal.mergeEquivalents()
-    minimal.beautify()
-    return minimal
+  minimize () {
+    this.determinize()
+    this.removeUnreachable()
+    this.removeDead()
+    this.mergeEquivalents()
+    this.beautify()
   }
 
   /**
@@ -770,19 +768,19 @@ class NFA {
    */
   static complement (dfa) {
     // Apply properties
-    const reversedDFA = new NFA(dfa.start, dfa.accept, dfa.table)
-    reversedDFA.determinize()
-    reversedDFA.complete()
+    const complementedNFA = new NFA(dfa.start, dfa.accept, dfa.table)
+    complementedNFA.determinize()
+    complementedNFA.complete()
 
     // Gets states that are not accept states
     const nonAccept = Object
-      .keys(reversedDFA.table)
-      .filter(i => !reversedDFA.accept.includes(i))
+      .keys(complementedNFA.table)
+      .filter(i => !complementedNFA.accept.includes(i))
 
     // Switch
-    reversedDFA.accept = nonAccept
+    complementedNFA.accept = nonAccept
 
-    return reversedDFA
+    return complementedNFA
   }
 }
 

--- a/src/nfa.js
+++ b/src/nfa.js
@@ -444,30 +444,27 @@ class NFA {
    */
   static concat (fa1, fa2) {
     // assert both automatas don't have states with same name
-    fa1.beautifyQn()
-    fa2.beautifyQn(Object.keys(fa1).length - 1)
+    fa1.beautify()
+    fa2.beautify(Object.keys(fa1).length)
+
     const newStart = fa1.start
     let newTable = Object.assign({}, fa1.table)
     const newAccept = fa2.accept
-    Object.entries(fa2.table[fa2.start]).forEach(([char, states]) => {
+
+    const entries = Object.entries(fa2.table[fa2.start])
+    for (const [char, states] of entries) {
       for (const finalState of fa1.accept) {
-        if (newTable[finalState][char] === undefined) {
-          newTable[finalState][char] = new Set(states)
-        } else {
-          for (const state of states) {
-            newTable[finalState][char].add(state)
-          }
-        }
-      }
-    })
-    newTable = Object.assign(newTable, fa2.table)
-    if (fa2.accept.has(fa2.start)) {
-      for (const acceptState of fa1.accept) {
-        newAccept.add(acceptState)
+        newTable[finalState][char].push(...states)
       }
     }
+
+    newTable = Object.assign(newTable, fa2.table)
+    if (fa2.accept.includes(fa2.start)) {
+      newAccept.push(...fa1.accept)
+    }
+
     return new NFA(newStart, newAccept, newTable)
-}
+  }
 
   /**
    * @brief produces the automata representing the star of the

--- a/src/re.js
+++ b/src/re.js
@@ -14,7 +14,7 @@ class RE {
     const alpha = reString
       .split('')
       .filter(i => i.match(ALPHABET))
-    this.alphabet = new Set(alpha)
+    this.alphabet = Array.from(new Set(alpha))
   }
 
   toDFA () {
@@ -76,7 +76,7 @@ class RE {
         // Composition already found, just add transition
         if (compMap.has(newCompName)) {
           const oldState = compMap.get(newCompName)
-          table[state][symbol] = new Set([ oldState ])
+          table[state][symbol] = [ oldState ]
           continue
         }
 
@@ -85,7 +85,7 @@ class RE {
         table[newState] = {}
 
         // Add transition from current state to it
-        table[state][symbol] = new Set([ newState ])
+        table[state][symbol] = [ newState ]
 
         // Add to map and stack
         compMap.set(newCompName, newState)
@@ -93,7 +93,7 @@ class RE {
       }
     }
 
-    return new NFA(start, accept, table)
+    return new NFA(start, Array.from(accept), table)
   }
 
   getCompositions () {

--- a/test/test_grammar.js
+++ b/test/test_grammar.js
@@ -3,7 +3,6 @@ const NFA = require('../src/nfa')
 const Grammar = require('../src/grammar')
 
 describe('Grammar', function () {
-  describe('#constructor()', function () {})
   describe('#fromNFA', function () {
     it('Should transform a NFA into a regular grammar', function () {
       // language = odd number of a's
@@ -13,13 +12,18 @@ describe('Grammar', function () {
         'S': { 'a': [ 'A' ] },
         'A': { 'a': [ 'S' ] }
       }
-      const dfa = new NFA(start, accept, table)
+      const nfa = new NFA(start, accept, table)
+
       const productions = {
         'S': [ 'aA', 'a' ],
         'A': [ 'aS' ]
       }
-      assert.deepStrictEqual(Grammar.fromNFA(dfa), new Grammar(start, productions))
+      const expected = new Grammar(start, productions)
+
+      const result = Grammar.fromNFA(nfa)
+      assert.deepStrictEqual(result, expected)
     })
+
     it('Should add epsilon if NFA accepts it', function () {
       // language = even number of a's
       const start = 'S'

--- a/test/test_grammar.js
+++ b/test/test_grammar.js
@@ -32,13 +32,17 @@ describe('Grammar', function () {
         'S': { 'a': [ 'A' ] },
         'A': { 'a': [ 'S' ] }
       }
-      const dfa = new NFA(start, accept, table)
+      const nfa = new NFA(start, accept, table)
+
       const productions = {
         "S'": [ 'aA', '&' ],
         'S': [ 'aA' ],
         'A': [ 'aS', 'a' ]
       }
-      assert.deepStrictEqual(Grammar.fromNFA(dfa), new Grammar("S'", productions))
+      const expected = new Grammar(start + "'", productions)
+
+      const result = Grammar.fromNFA(nfa)
+      assert.deepStrictEqual(result, expected)
     })
   })
 })

--- a/test/test_nfa.js
+++ b/test/test_nfa.js
@@ -690,30 +690,31 @@ describe('NFA', function () {
     })
   })
 
-  describe('#reverse', () => {
-    it('should reverse a already complete and deterministic FA', () => {
-      const start0 = 'S'
-      const accept0 = [ 'S' ]
-      const table0 = {
+  describe.only('#complement', function () {
+    it('Should get the complement of an already complete and deterministic FA', function () {
+      const start = 'S'
+      const accept = [ 'S' ]
+      const table = {
         'S': { 'a': [ 'A' ], 'b': [ 'S' ] },
         'A': { 'a': [ 'B' ], 'b': [ 'A' ] },
         'B': { 'a': [ 'S' ], 'b': [ 'B' ] }
       }
-      const nfa0 = new NFA(start0, accept0, table0)
+      const nfa = new NFA(start, accept, table)
 
-      const expectedStart = 'S'
-      const expectedFinalStates = [ 'A', 'B' ]
-      const expectedTable = {
+      const expStart = 'S'
+      const expAccept = [ 'A', 'B' ]
+      const expTable = {
         'S': { 'a': [ 'A' ], 'b': [ 'S' ] },
         'A': { 'a': [ 'B' ], 'b': [ 'A' ] },
         'B': { 'a': [ 'S' ], 'b': [ 'B' ] }
       }
+      const expected = new NFA(expStart, expAccept, expTable)
 
-      const reversedNFA0 = NFA.reverse(nfa0)
-      const expected = new NFA(expectedStart, expectedFinalStates, expectedTable)
-      assert.deepStrictEqual(reversedNFA0, expected)
+      const complement = NFA.complement(nfa)
+      assert.deepStrictEqual(complement, expected)
     })
-    it('should reverse a incomplete FA', () => {
+
+    it('Should get the complement of an incomplete FA', function () {
       const start = 'q0'
       const accept = [ 'q0', 'q1' ]
       const table = {
@@ -724,17 +725,19 @@ describe('NFA', function () {
       }
       const nfa = new NFA(start, accept, table)
 
-      const expectedStart = 'q0'
-      const expectedAccept = [ 'q2', 'q3', 'qdead' ]
-      const expectedTable = {
+      const expStart = 'q0'
+      const expAccept = [ 'q2', 'q3', 'qdead' ]
+      const expTable = {
         'q0': { 'a': [ 'q2' ], 'b': [ 'q1' ] },
         'q1': { 'a': [ 'q2' ], 'b': [ 'qdead' ] },
         'q2': { 'a': [ 'q0' ], 'b': [ 'q3' ] },
         'q3': { 'a': [ 'q0' ], 'b': [ 'qdead' ] },
         'qdead': { 'a': [ 'qdead' ], 'b': [ 'qdead' ] }
       }
-      const expected = new NFA(expectedStart, expectedAccept, expectedTable)
-      assert.deepStrictEqual(NFA.reverse(nfa), expected)
+      const expected = new NFA(expStart, expAccept, expTable)
+
+      const complement = NFA.complement(nfa)
+      assert.deepStrictEqual(complement, expected)
     })
   })
 

--- a/test/test_nfa.js
+++ b/test/test_nfa.js
@@ -812,28 +812,101 @@ describe('NFA', function () {
     })
   })
 
-  describe.skip('#minimize', function () {
+  describe('#removeState', function () {
+    it('Should remove state from automata', function () {
+      const start = 'A'
+      const accept = [ 'A', 'B' ]
+      const table = {
+        A: { a: [ 'B' ], b: [ 'A' ] },
+        B: { a: [ 'C' ], b: [ 'A' ] },
+        C: { b: [ 'A' ] }
+      }
+      const nfa = new NFA(start, accept, table)
+
+      const expAccept = [ 'B' ]
+      const expTable = {
+        B: { a: [ 'C' ] },
+        C: { b: [] }
+      }
+      const expected = new NFA('', expAccept, expTable)
+
+      nfa.removeState('A')
+      assert.deepStrictEqual(nfa, expected)
+    })
+  })
+
+  describe('#removeUnreachable', function () {
+    it('Should remove unreachable states', function () {
+      const start = 'A'
+      const accept = [ 'A', 'D', 'G' ]
+      const table = {
+        A: { a: [ 'G' ], b: [ 'B' ] },
+        B: { a: [ 'F' ], b: [ 'E' ] },
+        C: { a: [ 'C' ], b: [ 'G' ] },
+        D: { a: [ 'A' ], b: [ 'H' ] },
+        E: { a: [ 'E' ], b: [ 'A' ] },
+        F: { a: [ 'B' ], b: [ 'C' ] },
+        G: { a: [ 'G' ], b: [ 'F' ] },
+        H: { a: [ 'H' ], b: [ 'D' ] }
+      }
+      const nfa = new NFA(start, accept, table)
+
+      const expected = {
+        A: { a: [ 'G' ], b: [ 'B' ] },
+        B: { a: [ 'F' ], b: [ 'E' ] },
+        C: { a: [ 'C' ], b: [ 'G' ] },
+        E: { a: [ 'E' ], b: [ 'A' ] },
+        F: { a: [ 'B' ], b: [ 'C' ] },
+        G: { a: [ 'G' ], b: [ 'F' ] }
+      }
+
+      nfa.removeUnreachable()
+      assert.deepStrictEqual(nfa.table, expected)
+    })
+  })
+
+  describe('#removeDead', function () {
+    it('Should remove dead states', function () {
+      const start = 'A'
+      const accept = [ 'A' ]
+      const table = {
+        A: { a: [ 'B' ], b: [ 'A' ] },
+        B: { a: [ 'C' ], b: [ 'B' ] },
+        C: { a: [ 'C' ], b: [ 'B' ] }
+      }
+      const nfa = new NFA(start, accept, table)
+
+      const expected = {
+        A: { a: [], b: [ 'A' ] }
+      }
+
+      nfa.removeDead()
+      assert.deepStrictEqual(nfa.table, expected)
+    })
+  })
+
+  describe('#minimize', function () {
     it('should minimize a AF', function () {
       const start = 'A'
       const accept = [ 'A', 'D', 'G' ]
       const table = {
-        'A': { 'a': [ 'G' ], 'b': [ 'B' ] },
-        'B': { 'a': [ 'F' ], 'b': [ 'E' ] },
-        'C': { 'a': [ 'C' ], 'b': [ 'G' ] },
-        'D': { 'a': [ 'A' ], 'b': [ 'H' ] },
-        'E': { 'a': [ 'E' ], 'b': [ 'A' ] },
-        'F': { 'a': [ 'B' ], 'b': [ 'C' ] },
-        'G': { 'a': [ 'G' ], 'b': [ 'F' ] },
-        'H': { 'a': [ 'H' ], 'b': [ 'D' ] }
+        A: { a: [ 'G' ], b: [ 'B' ] },
+        B: { a: [ 'F' ], b: [ 'E' ] },
+        C: { a: [ 'C' ], b: [ 'G' ] },
+        D: { a: [ 'A' ], b: [ 'H' ] },
+        E: { a: [ 'E' ], b: [ 'A' ] },
+        F: { a: [ 'B' ], b: [ 'C' ] },
+        G: { a: [ 'G' ], b: [ 'F' ] },
+        H: { a: [ 'H' ], b: [ 'D' ] }
       }
       const nfa = new NFA(start, accept, table)
 
       const expStart = 'q0'
       const expAccept = [ 'q0' ]
       const expTable = {
-        'q0': { 'a': [ 'q0' ], 'b': [ 'q1' ] },
-        'q1': { 'a': [ 'q1' ], 'b': [ 'q2' ] },
-        'q2': { 'a': [ 'q2' ], 'b': [ 'q0' ] }
+        q0: { a: [ 'q0' ], b: [ 'q1' ] },
+        q1: { a: [ 'q1' ], b: [ 'q2' ] },
+        q2: { a: [ 'q2' ], b: [ 'q0' ] }
       }
       const expected = new NFA(expStart, expAccept, expTable)
 

--- a/test/test_nfa.js
+++ b/test/test_nfa.js
@@ -628,7 +628,7 @@ describe('NFA', function () {
     })
   })
 
-  describe.only('#concat', function () {
+  describe('#concat', function () {
     it('should concat two FAs', function () {
       const start0 = 'S'
       const accept0 = [ 'B' ]

--- a/test/test_nfa.js
+++ b/test/test_nfa.js
@@ -690,7 +690,7 @@ describe('NFA', function () {
     })
   })
 
-  describe.only('#complement', function () {
+  describe('#complement', function () {
     it('Should get the complement of an already complete and deterministic FA', function () {
       const start = 'S'
       const accept = [ 'S' ]
@@ -741,14 +741,15 @@ describe('NFA', function () {
     })
   })
 
-  describe('#intersection', () => {
-    it('should return the intersection of two FAs.', () => {
+  describe('#intersection', function () {
+    it('should return the intersection of two FAs.', function () {
       const start0 = 'S'
       const accept0 = [ 'S', 'A' ]
       const table0 = {
         'S': { '0': [ 'A' ], '1': [ 'S' ] },
         'A': { '1': [ 'S' ] }
       }
+      const nfa0 = new NFA(start0, accept0, table0)
 
       const start1 = 'S'
       const accept1 = [ 'S', 'A' ]
@@ -756,12 +757,11 @@ describe('NFA', function () {
         'S': { '0': [ 'S' ], '1': [ 'A' ] },
         'A': { '0': [ 'S' ] }
       }
-      const nfa0 = new NFA(start0, accept0, table0)
       const nfa1 = new NFA(start1, accept1, table1)
 
-      const expectedStart = 'qinitial'
-      const expectedAccept = [ 'qinitial', 'q1,q3', 'q0,q4' ]
-      const expectedTable = {
+      const expStart = 'qinitial'
+      const expAccept = [ 'qinitial', 'q0,q4', 'q1,q3' ]
+      const expTable = {
         'qinitial': { '0': [ 'q1,q3' ], '1': [ 'q0,q4' ] },
         'q1,q3': { '0': [ 'q2,q3' ], '1': [ 'q0,q4' ] },
         'q0,q4': { '0': [ 'q1,q3' ], '1': [ 'q0,q5' ] },
@@ -771,46 +771,49 @@ describe('NFA', function () {
         'q1,q5': { '0': [ 'q2,q5' ], '1': [ 'q0,q5' ] },
         'q2,q5': { '0': [ 'q2,q5' ], '1': [ 'q2,q5' ] }
       }
-      const expected = new NFA(expectedStart, expectedAccept, expectedTable)
+      const expected = new NFA(expStart, expAccept, expTable)
+
       const intersection = NFA.intersection(nfa0, nfa1)
       assert.deepStrictEqual(intersection, expected)
     })
   })
 
-  describe('#diff', () => {
-    it('should get the diff between two AFs', () => {
+  describe('#diff', function () {
+    it('should get the diff between two AFs', function () {
       const start0 = 'S'
       const accept0 = [ 'A' ]
       const table0 = {
         'S': { '0': [ 'A' ] },
         'A': { '0': [ 'A' ], '1': [ 'A' ] }
       }
+      const nfa0 = new NFA(start0, accept0, table0)
+
       const start1 = 'S'
       const accept1 = [ 'A' ]
       const table1 = {
         'S': { '0': [ 'A' ], '1': [ 'S' ] },
         'A': { '0': [ 'A' ], '1': [ 'S' ] }
       }
-      const nfa0 = new NFA(start0, accept0, table0)
       const nfa1 = new NFA(start1, accept1, table1)
 
-      const expectedStart = 'qinitial'
-      const expectedAccept = [ 'q1,q3' ]
-      const expectedTable = {
+      const expStart = 'qinitial'
+      const expAccept = [ 'q1,q3' ]
+      const expTable = {
         'qinitial': { '0': [ 'q1,q4' ], '1': [ 'q2,q3' ] },
         'q1,q4': { '0': [ 'q1,q4' ], '1': [ 'q1,q3' ] },
         'q2,q3': { '0': [ 'q2,q4' ], '1': [ 'q2,q3' ] },
         'q1,q3': { '0': [ 'q1,q4' ], '1': [ 'q1,q3' ] },
         'q2,q4': { '0': [ 'q2,q4' ], '1': [ 'q2,q3' ] }
       }
-      const expected = new NFA(expectedStart, expectedAccept, expectedTable)
+      const expected = new NFA(expStart, expAccept, expTable)
+
       const diff = NFA.diff(nfa0, nfa1)
       assert.deepStrictEqual(diff, expected)
     })
   })
 
-  describe('#minimize', () => {
-    it('should minimize a AF', () => {
+  describe.skip('#minimize', function () {
+    it('should minimize a AF', function () {
       const start = 'A'
       const accept = [ 'A', 'D', 'G' ]
       const table = {
@@ -823,17 +826,18 @@ describe('NFA', function () {
         'G': { 'a': [ 'G' ], 'b': [ 'F' ] },
         'H': { 'a': [ 'H' ], 'b': [ 'D' ] }
       }
-      const nfa0 = new NFA(start, accept, table)
+      const nfa = new NFA(start, accept, table)
 
-      const expectedStart = 'q0'
-      const expectedAccept = [ 'q0' ]
-      const expectedTable = {
+      const expStart = 'q0'
+      const expAccept = [ 'q0' ]
+      const expTable = {
         'q0': { 'a': [ 'q0' ], 'b': [ 'q1' ] },
         'q1': { 'a': [ 'q1' ], 'b': [ 'q2' ] },
         'q2': { 'a': [ 'q2' ], 'b': [ 'q0' ] }
       }
-      const expected = new NFA(expectedStart, expectedAccept, expectedTable)
-      const minimal = NFA.minimize(nfa0)
+      const expected = new NFA(expStart, expAccept, expTable)
+
+      const minimal = NFA.minimize(nfa)
       assert.deepStrictEqual(minimal, expected)
     })
   })

--- a/test/test_nfa.js
+++ b/test/test_nfa.js
@@ -665,28 +665,28 @@ describe('NFA', function () {
     })
   })
 
-  describe('#star', () => {
-    it('should star a FA', () => {
-      const start0 = 'S'
-      const accept0 = [ 'B' ]
-      const table0 = {
+  describe.only('#star', function () {
+    it('should star a FA', function () {
+      const start = 'S'
+      const accept = [ 'B' ]
+      const table = {
         'S': { 'a': [ 'A' ] },
         'A': { 'b': [ 'B' ] },
         'B': {}
       }
-      const nfa0 = new NFA(start0, accept0, table0)
+      const nfa = new NFA(start, accept, table)
 
-      const expectedStart = 'S'
-      const expectedFinalStates = [ 'B' ]
-      const expectedTable = {
+      const expStart = 'S'
+      const expAccept = [ 'B' ]
+      const expTable = {
         'S': { 'a': [ 'A' ] },
         'A': { 'b': [ 'B' ] },
         'B': { 'a': [ 'A' ] }
       }
+      const expected = new NFA(expStart, expAccept, expTable)
 
-      const nfa0Star = NFA.star(nfa0)
-      const expected = new NFA(expectedStart, expectedFinalStates, expectedTable)
-      assert.deepStrictEqual(nfa0Star, expected)
+      const star = NFA.star(nfa)
+      assert.deepStrictEqual(star, expected)
     })
   })
 

--- a/test/test_nfa.js
+++ b/test/test_nfa.js
@@ -910,8 +910,8 @@ describe('NFA', function () {
       }
       const expected = new NFA(expStart, expAccept, expTable)
 
-      const minimal = NFA.minimize(nfa)
-      assert.deepStrictEqual(minimal, expected)
+      nfa.minimize()
+      assert.deepStrictEqual(nfa, expected)
     })
   })
 })

--- a/test/test_nfa.js
+++ b/test/test_nfa.js
@@ -538,7 +538,7 @@ describe('NFA', function () {
   })
 
   describe('#beautify', function () {
-    it('should transform all original states into q0, q1, ..., qn', function () {
+    it('Should transform all original states into q0, q1, ..., qn', function () {
       const start = 'S'
       const accept = [ 'B' ]
       const table = {
@@ -563,7 +563,7 @@ describe('NFA', function () {
   })
 
   describe('#union', function () {
-    it('should unite two FAs', function () {
+    it('Should unite two FAs', function () {
       const start0 = 'S'
       const accept0 = [ 'B' ]
       const table0 = {
@@ -600,8 +600,8 @@ describe('NFA', function () {
     })
   })
 
-  describe('#complete', () => {
-    it('should complete the transitions of a incomplete automata', () => {
+  describe('#complete', function () {
+    it('Should complete the transitions of a incomplete automata', function () {
       const start = 'q0'
       const accept = [ 'qf' ]
       const table = {
@@ -611,6 +611,7 @@ describe('NFA', function () {
         'q3': {},
         'qf': {}
       }
+      const nfa = new NFA(start, accept, table)
 
       const expectedTable = {
         'q0': { 'a': [ 'q1' ], 'b': [ 'q1' ], 'c': [ 'q1' ] },
@@ -620,16 +621,15 @@ describe('NFA', function () {
         'qf': { 'a': [ 'qdead' ], 'b': [ 'qdead' ], 'c': [ 'qdead' ] },
         'qdead': { 'a': [ 'qdead' ], 'b': [ 'qdead' ], 'c': [ 'qdead' ] }
       }
-
-      const nfa1 = new NFA(start, accept, table)
-      nfa1.complete()
       const expected = new NFA(start, accept, expectedTable)
-      assert.deepStrictEqual(nfa1, expected)
+
+      nfa.complete()
+      assert.deepStrictEqual(nfa, expected)
     })
   })
 
   describe('#concat', function () {
-    it('should concat two FAs', function () {
+    it('Should concat two FAs', function () {
       const start0 = 'S'
       const accept0 = [ 'B' ]
       const table0 = {
@@ -665,8 +665,8 @@ describe('NFA', function () {
     })
   })
 
-  describe.only('#star', function () {
-    it('should star a FA', function () {
+  describe('#star', function () {
+    it('Should star a FA', function () {
       const start = 'S'
       const accept = [ 'B' ]
       const table = {

--- a/test/test_nfa.js
+++ b/test/test_nfa.js
@@ -3,36 +3,39 @@ const NFA = require('../src/nfa')
 
 describe('NFA', function () {
   describe('#constructor', function () {
-    it('Should separate the alphabet passed', function () {
-      const start = 'S'
-      const accept = [ 'A' ]
-      const table = {
-        'S': { 'a': [ 'S', 'A' ], 'b': [ 'A' ], 'c': [ 'C' ] },
-        'A': { 'a': [ 'S', 'A' ], 'b': [ 'C' ], 'c': [ 'A' ] },
-        'C': { 'a': [ 'S', 'A' ], 'b': [ 'C' ], 'c': [ 'S' ] }
-      }
-      const alpha = new Set([ 'a', 'b', 'c' ])
-
-      const dfa = new NFA(start, accept, table)
-      assert.deepStrictEqual(dfa.alphabet, alpha)
-    })
-
-    it('Should filter out useless transitions', function () {
+    it('Should fill out the transitions', function () {
       const start = 'q0'
       const accept = [ 'q2' ]
       const table = {
-        'q0': { 'a': [], 'b': [ 'q1' ] },
-        'q1': { 'a': [ 'q2' ], 'b': [] },
-        'q2': { 'a': [], 'b': [] }
+        q0: { b: [ 'q1' ] },
+        q1: { a: [ 'q2' ] },
+        q2: { }
       }
       const nfa = new NFA(start, accept, table)
 
       const expect = {
-        'q0': { 'b': new Set([ 'q1' ]) },
-        'q1': { 'a': new Set([ 'q2' ]) },
-        'q2': {}
+        q0: { a: [], b: [ 'q1' ] },
+        q1: { a: [ 'q2' ], b: [] },
+        q2: { a: [], b: [] }
       }
       assert.deepStrictEqual(nfa.table, expect)
+    })
+  })
+
+  describe('#alphabet', function () {
+    it('Should return the alphabet of NFA', function () {
+      const start = 'S'
+      const accept = [ 'A' ]
+      const table = {
+        S: { a: [ 'S', 'A' ], b: [ 'A' ], c: [ 'C' ] },
+        A: { a: [ 'S', 'A' ], b: [ 'C' ], c: [ 'A' ] },
+        C: { a: [ 'S', 'A' ], b: [ 'C' ], c: [ 'S' ] }
+      }
+      const nfa = new NFA(start, accept, table)
+
+      const expect = [ 'a', 'b', 'c' ]
+      const result = nfa.alphabet
+      assert.deepStrictEqual(result, expect)
     })
   })
 
@@ -41,8 +44,8 @@ describe('NFA', function () {
       const start = 'S'
       const accept = [ 'A' ]
       const table = {
-        'S': { 'a': [ 'S' ] },
-        'A': { 'a': [ 'A' ] }
+        S: { a: [ 'S' ] },
+        A: { a: [ 'A' ] }
       }
 
       const nfa = new NFA(start, accept, table)
@@ -53,8 +56,8 @@ describe('NFA', function () {
       const start = 'S'
       const accept = [ 'A' ]
       const table = {
-        'S': { 'a': [ 'S', 'A' ] },
-        'A': { 'a': [ 'A' ] }
+        S: { a: [ 'S', 'A' ] },
+        A: { a: [ 'A' ] }
       }
 
       const nfa = new NFA(start, accept, table)
@@ -63,78 +66,122 @@ describe('NFA', function () {
   })
 
   describe('#getTransitions', function () {
-    it('Should return the possible transitions from a list of states', function () {
-      const start0 = 'S'
-      const accept0 = [ 'C' ]
-      const table0 = {
-        'S': { 'a': [ 'A', 'B' ] },
-        'A': { 'a': [ 'A', 'C' ] },
-        'B': { 'a': [ 'C' ], 'b': [ 'B' ] },
-        'C': {}
-      }
-      const nfa0 = new NFA(start0, accept0, table0)
+    const start = 'S'
+    const accept = [ 'C' ]
+    const table = {
+      S: { a: [ 'A', 'B' ] },
+      A: { a: [ 'A', 'C' ] },
+      B: { a: [ 'C' ], b: [ 'B' ] },
+      C: {}
+    }
+    const nfa = new NFA(start, accept, table)
 
-      const expected0 = new Set([ 'a' ])
-      const result0 = nfa0.getTransitions([ 'S', 'A' ])
-      assert.deepStrictEqual(expected0, result0)
+    const testTransitions = [
+      { input: [ 'S', 'A' ], expected: [ 'a' ] },
+      { input: [ 'B', 'C' ], expected: [ 'a', 'b' ] },
+      { input: [ 'C' ], expected: [] }
+    ]
 
-      const expected1 = new Set([ 'a', 'b' ])
-      const result1 = nfa0.getTransitions([ 'B', 'C' ])
-      assert.deepStrictEqual(expected1, result1)
-
-      const expected2 = new Set([])
-      const result2 = nfa0.getTransitions([ 'C' ])
-      assert.deepStrictEqual(expected2, result2)
+    testTransitions.forEach(function (t) {
+      it('Should return the possible transitions from a list of states', function () {
+        const expect = t.expected
+        const result = nfa.getTransitions(t.input)
+        assert.deepStrictEqual(result, expect)
+      })
     })
   })
 
   describe('#getReach', function () {
-    it('Should return reachable states from passed state and char', function () {
-      const start0 = 'S'
-      const accept0 = [ 'C' ]
-      const table0 = {
-        'S': { 'a': [ 'A', 'B' ] },
-        'A': { 'a': [ 'A', 'C' ] },
-        'B': {'a': [ 'C' ], 'b': [ 'B' ]},
-        'C': {}
+    const start = 'S'
+    const accept = [ 'C' ]
+    const table = {
+      S: { a: [ 'A', 'B' ] },
+      A: { a: [ 'A', 'C' ] },
+      B: { a: [ 'C' ], b: [ 'B' ] },
+      C: {}
+    }
+    const nfa = new NFA(start, accept, table)
+
+    const testGetReach0 = [
+      { input1: [ 'S', 'A' ], input2: 'a', expected: [ 'A', 'B', 'C' ] },
+      { input1: [ 'A', 'B' ], input2: 'a', expected: [ 'A', 'C' ] },
+      { input1: [ 'A', 'B' ], input2: 'b', expected: [ 'B' ] }
+    ]
+
+    testGetReach0.forEach(function (t) {
+      it('Should return reachable states from passed state and char', function () {
+        const expected = t.expected
+        const result = nfa.getReach(t.input1, t.input2)
+        assert.deepStrictEqual(result, expected)
+      })
+    })
+  })
+
+  describe('#getReach', function () {
+    // Figure 2.9
+    // John E. Hopcroft, Rajeev Motwani, Jeffrey D. Ullman
+    // Introduction to Automata Theory, Languages, and Computation, 3rd ed.
+    const start = 'q0'
+    const accept = [ 'q2' ]
+    const table = {
+      q0: { '0': [ 'q0', 'q1' ], '1': [ 'q0' ] },
+      q1: { '1': [ 'q2' ] },
+      q2: {}
+    }
+    const nfa = new NFA(start, accept, table)
+
+    const testGetReach1 = [
+      { input1: [ 'q0', 'q1' ], input2: '0', expected: [ 'q0', 'q1' ] },
+      { input1: [ 'q0', 'q1' ], input2: '0', expected: [ 'q0', 'q1' ] },
+      { input1: [ 'q0', 'q2' ], input2: '1', expected: [ 'q0' ] }
+    ]
+
+    testGetReach1.forEach(function (t) {
+      it('Should return reachable states from passed state and char', function () {
+        const expected = t.expected
+        const result = nfa.getReach(t.input1, t.input2)
+        assert.deepStrictEqual(result, expected)
+      })
+    })
+  })
+
+  describe('#getEpslonClosure', function () {
+    it('Should return the closure of epslon', function () {
+      const nstart = 'A'
+      const naccept = [ 'B' ]
+      const ntable = {
+        'A': { 'a': [ 'A' ], '&': [ 'B' ] },
+        'B': { 'b': [ 'B' ], '&': [ 'C' ] },
+        'C': { 'c': [ 'C' ] }
       }
-      const nfa0 = new NFA(start0, accept0, table0)
+      const nfa = new NFA(nstart, naccept, ntable)
 
-      const expected0 = new Set([ 'A', 'B', 'C' ])
-      const result0 = nfa0.getReach([ 'S', 'A' ], 'a')
-      assert.deepStrictEqual(expected0, result0)
+      const expect = [ 'A', 'B', 'C' ]
+      const result = nfa.getEpslonClosure([ 'A' ])
+      assert.deepStrictEqual(expect, result)
+    })
 
-      const expected1 = new Set([ 'A', 'C' ])
-      const result1 = nfa0.getReach([ 'A', 'B' ], 'a')
-      assert.deepStrictEqual(expected1, result1)
-
-      const expected2 = new Set([ 'B' ])
-      const result2 = nfa0.getReach([ 'A', 'B' ], 'b')
-      assert.deepStrictEqual(expected2, result2)
-
-      // Figure 2.9
+    it('Should return the closure of epslon', function () {
+      // Fig. 2.21
       // John E. Hopcroft, Rajeev Motwani, Jeffrey D. Ullman
       // Introduction to Automata Theory, Languages, and Computation, 3rd ed.
-      const start1 = 'q0'
-      const accept1 = [ 'q2' ]
-      const table1 = {
-        'q0': { '0': [ 'q0', 'q1' ], '1': [ 'q0' ] },
-        'q1': { '1': [ 'q2' ] },
-        'q2': {}
+      const nstart = '1'
+      const naccept = [ '7' ]
+      const ntable = {
+        '1': { '&': [ '2', '4' ] },
+        '2': { '&': [ '3' ] },
+        '3': { '&': [ '6' ] },
+        '4': { 'a': [ '5' ] },
+        '5': { 'b': [ '6' ], '&': [ '7' ] },
+        '6': {},
+        '7': {}
       }
-      const nfa1 = new NFA(start1, accept1, table1)
 
-      const expected3 = new Set([ 'q0', 'q1' ])
-      const result3 = nfa1.getReach([ 'q0', 'q1' ], '0')
-      assert.deepStrictEqual(expected3, result3)
+      const nfa = new NFA(nstart, naccept, ntable)
 
-      const expected4 = new Set([ 'q0', 'q1' ])
-      const result4 = nfa1.getReach([ 'q0' ], '0')
-      assert.deepStrictEqual(expected4, result4)
-
-      const expected5 = new Set([ 'q0', 'q2' ])
-      const result5 = nfa1.getReach([ 'q0', 'q1' ], '1')
-      assert.deepStrictEqual(expected5, result5)
+      const expect = [ '1', '2', '3', '4', '6' ]
+      const result = nfa.getEpslonClosure([ '1' ])
+      assert.deepStrictEqual(expect, result)
     })
   })
 
@@ -142,9 +189,9 @@ describe('NFA', function () {
     it('Should remove all epslon transitions, if any', function () {
       // Test copied from:
       // https://cs.stackexchange.com/a/22093
-      const start0 = 'q0'
-      const accept0 = [ 'q5' ]
-      const table0 = {
+      const start = 'q0'
+      const accept = [ 'q5' ]
+      const table = {
         q0: { '&': [ 'q1' ], b: [ 'q3' ] },
         q1: { '&': [ 'q2' ], a: [ 'q3' ] },
         q2: { a: [ 'q4' ] },
@@ -153,24 +200,26 @@ describe('NFA', function () {
         q5: {}
       }
 
-      const nfa0 = new NFA(start0, accept0, table0)
-      nfa0.removeEpslon()
+      const nfa = new NFA(start, accept, table)
+      nfa.removeEpslon()
 
-      const expected0 = {
-        q0: { a: new Set([ 'q2', 'q3', 'q4' ]), b: new Set([ 'q3', 'q2' ]) },
-        q1: { a: new Set([ 'q2', 'q3', 'q4' ]) },
-        q2: { a: new Set([ 'q4' ]) },
-        q3: { a: new Set([ 'q4' ]), b: new Set([ 'q5' ]) },
-        q4: { a: new Set([ 'q5' ]), b: new Set([ 'q2', 'q3' ]) },
-        q5: {}
+      const expected = {
+        q0: { a: [ 'q2', 'q3', 'q4' ], b: [ 'q2', 'q3' ] },
+        q1: { a: [ 'q2', 'q3', 'q4' ], b: [] },
+        q2: { a: [ 'q4' ], b: [] },
+        q3: { a: [ 'q4' ], b: [ 'q5' ] },
+        q4: { a: [ 'q5' ], b: [ 'q2', 'q3' ] },
+        q5: { a: [], b: [] }
       }
-      const newAccept0 = new Set([ 'q5' ])
-      assert.deepStrictEqual(nfa0.accept, newAccept0)
-      assert.deepStrictEqual(nfa0.table, expected0)
+      const newAccept = [ 'q5' ]
+      assert.deepStrictEqual(nfa.accept, newAccept)
+      assert.deepStrictEqual(nfa.table, expected)
+    })
 
-      const start1 = '1'
-      const accept1 = [ '15' ]
-      const table1 = {
+    it('Should remove all epslon transitions, if any', function () {
+      const start = '1'
+      const accept = [ '15' ]
+      const table = {
         '1': { '&': [ '2', '4' ] },
         '2': { 'b': [ '3' ] },
         '3': { '&': [ '6' ] },
@@ -188,68 +237,90 @@ describe('NFA', function () {
         '15': {}
       }
 
-      const nfa1 = new NFA(start1, accept1, table1)
-      nfa1.removeEpslon()
+      const nfa = new NFA(start, accept, table)
+      nfa.removeEpslon()
 
       // I took too long on this one...
-      const expected1 = {
+      const expected = {
         '1': {
-          a: new Set([ '8', '9', '11', '10', '14', '15' ]),
-          b: new Set([ '3', '6', '7', '8', '9', '11', '12', '15' ])
+          a: [ '8', '9', '11', '10', '14', '15' ].sort(),
+          b: [ '3', '6', '7', '8', '9', '11', '12', '15' ].sort(),
+          c: []
         },
         '2': {
-          b: new Set([ '3', '6', '7', '8', '9', '11', '15' ])
+          a: [],
+          b: [ '3', '6', '7', '8', '9', '11', '15' ].sort(),
+          c: []
         },
         '3': {
-          a: new Set([ '8', '9', '11', '10', '14', '15' ]),
-          b: new Set([ '12' ])
+          a: [ '8', '9', '11', '10', '14', '15' ].sort(),
+          b: [ '12' ].sort(),
+          c: []
         },
         '4': {
-          a: new Set([ '8', '9', '11', '10', '14', '15' ]),
-          b: new Set([ '12' ])
+          a: [ '8', '9', '11', '10', '14', '15' ].sort(),
+          b: [ '12' ].sort(),
+          c: []
         },
         '5': {
-          a: new Set([ '8', '9', '11', '10', '14', '15' ]),
-          b: new Set([ '12' ])
+          a: [ '8', '9', '11', '10', '14', '15' ].sort(),
+          b: [ '12' ].sort(),
+          c: []
         },
         '6': {
-          a: new Set([ '8', '9', '11', '10', '14', '15' ]),
-          b: new Set([ '12' ])
+          a: [ '8', '9', '11', '10', '14', '15' ].sort(),
+          b: [ '12' ].sort(),
+          c: []
         },
         '7': {
-          a: new Set([ '8', '9', '11', '10', '14', '15' ]),
-          b: new Set([ '12' ])
+          a: [ '8', '9', '11', '10', '14', '15' ].sort(),
+          b: [ '12' ].sort(),
+          c: []
         },
         '8': {
-          a: new Set([ '8', '9', '11', '10', '14', '15' ]),
-          b: new Set([ '12' ])
+          a: [ '8', '9', '11', '10', '14', '15' ].sort(),
+          b: [ '12' ].sort(),
+          c: []
         },
         '9': {
-          a: new Set([ '8', '9', '11', '10', '14', '15' ])
+          a: [ '8', '9', '11', '10', '14', '15' ].sort(),
+          b: [],
+          c: []
         },
         '10': {
-          a: new Set([ '8', '9', '11', '10', '14', '15' ]),
-          b: new Set([ '12' ])
+          a: [ '8', '9', '11', '10', '14', '15' ].sort(),
+          b: [ '12' ].sort(),
+          c: []
         },
         '11': {
-          b: new Set([ '12' ])
+          a: [],
+          b: [ '12' ].sort(),
+          c: []
         },
         '12': {
-          c: new Set([ '8', '9', '11', '13', '14', '15' ])
+          a: [],
+          b: [],
+          c: [ '8', '9', '11', '13', '14', '15' ].sort()
         },
         '13': {
-          a: new Set([ '8', '9', '11', '10', '14', '15' ]),
-          b: new Set([ '12' ])
+          a: [ '8', '9', '11', '10', '14', '15' ].sort(),
+          b: [ '12' ].sort(),
+          c: []
         },
         '14': {
-          a: new Set([ '8', '9', '11', '10', '14', '15' ]),
-          b: new Set([ '12' ])
+          a: [ '8', '9', '11', '10', '14', '15' ].sort(),
+          b: [ '12' ].sort(),
+          c: []
         },
-        '15': {}
+        '15': {
+          a: [],
+          b: [],
+          c: []
+        }
       }
-      const newAccept1 = new Set([ '1', '3', '4', '5', '6', '7', '8', '10', '13', '14', '15' ])
-      assert.deepStrictEqual(nfa1.accept, newAccept1)
-      assert.deepStrictEqual(nfa1.table, expected1)
+      const newAccept = [ '1', '3', '4', '5', '6', '7', '8', '10', '13', '14', '15' ].sort()
+      assert.deepStrictEqual(nfa.accept, newAccept)
+      assert.deepStrictEqual(nfa.table, expected)
     })
 
     it('Removing epslon transitions twice should make no difference', function () {
@@ -275,59 +346,22 @@ describe('NFA', function () {
     })
   })
 
-  describe('#getEpslonClosure', function () {
-    it('Should return the closure of epslon', function () {
-      const nstart0 = 'A'
-      const naccept0 = [ 'B' ]
-      const ntable0 = {
-        'A': { 'a': [ 'A' ], '&': [ 'B' ] },
-        'B': { 'b': [ 'B' ], '&': [ 'C' ] },
-        'C': { 'c': [ 'C' ] }
-      }
-
-      const nfa0 = new NFA(nstart0, naccept0, ntable0)
-
-      const expect0 = new Set([ 'A', 'B', 'C' ])
-      const result0 = nfa0.getEpslonClosure([ 'A' ])
-      assert.deepStrictEqual(expect0, result0)
-
-      // Fig. 2.21
-      // John E. Hopcroft, Rajeev Motwani, Jeffrey D. Ullman
-      // Introduction to Automata Theory, Languages, and Computation, 3rd ed.
-      const nstart1 = '1'
-      const naccept1 = [ '7' ]
-      const ntable1 = {
-        '1': { '&': [ '2', '4' ] },
-        '2': { '&': [ '3' ] },
-        '3': { '&': [ '6' ] },
-        '4': { 'a': [ '5' ] },
-        '5': { 'b': [ '6' ], '&': [ '7' ] },
-        '6': {},
-        '7': {}
-      }
-
-      const nfa1 = new NFA(nstart1, naccept1, ntable1)
-
-      const expect1 = new Set([ '1', '2', '3', '4', '6' ])
-      const result1 = nfa1.getEpslonClosure([ '1' ])
-      assert.deepStrictEqual(expect1, result1)
-    })
-  })
-
   describe('#determinize', function () {
     it('Should determinize the non-deterministic automaton', function () {
-      const nstart0 = 'S'
-      const naccept0 = [ 'C' ]
-      const ntable0 = {
+      // Non-deterministic
+      const nstart = 'S'
+      const naccept = [ 'C' ]
+      const ntable = {
         S: { a: [ 'A', 'B' ] },
         A: { a: [ 'A', 'C' ] },
         B: { a: [ 'C' ], b: [ 'B' ] },
         C: {}
       }
 
-      const dstart0 = 'S'
-      const daccept0 = [ 'A,C', 'C' ]
-      const dtable0 = {
+      // Deterministic
+      const dstart = 'S'
+      const daccept = [ 'A,C', 'C' ]
+      const dtable = {
         'S': { a: [ 'A,B' ] },
         'A,B': { a: [ 'A,C' ], b: [ 'B' ] },
         'A,C': { a: [ 'A,C' ] },
@@ -335,15 +369,18 @@ describe('NFA', function () {
         'C': {}
       }
 
-      const nfa0 = new NFA(nstart0, naccept0, ntable0)
-      const dfa0 = new NFA(dstart0, daccept0, dtable0)
-      nfa0.determinize()
-      assert.deepStrictEqual(nfa0, dfa0)
-      assert(nfa0.isDeterministic())
+      const nfa = new NFA(nstart, naccept, ntable)
+      const dfa = new NFA(dstart, daccept, dtable)
+      nfa.determinize()
 
-      const nstart1 = 'S'
-      const naccept1 = [ 'E' ]
-      const ntable1 = {
+      assert.deepStrictEqual(nfa, dfa)
+      assert(nfa.isDeterministic())
+    })
+
+    it('Should determinize the non-deterministic automaton', function () {
+      const nstart = 'S'
+      const naccept = [ 'E' ]
+      const ntable = {
         S: { a: [ 'B', 'E', 'D' ], b: [ 'E', 'A', 'C' ] },
         A: { a: [ 'E', 'B' ], b: [ 'A' ] },
         B: { a: [ 'A' ], b: [ 'B', 'E' ] },
@@ -351,26 +388,26 @@ describe('NFA', function () {
         D: { a: [ 'C', 'E' ], b: [ 'D' ] },
         E: {}
       }
-      const nfa1 = new NFA(nstart1, naccept1, ntable1)
+      const nfa = new NFA(nstart, naccept, ntable)
 
-      const dstart1 = 'S'
-      const daccept1 = [ 'B,D,E', 'A,C,E' ]
-      const dtable1 = {
+      const dstart = 'S'
+      const daccept = [ 'B,D,E', 'A,C,E' ].sort()
+      const dtable = {
         'S': { a: [ 'B,D,E' ], b: [ 'A,C,E' ] },
         'B,D,E': { a: [ 'A,C,E' ], b: [ 'B,D,E' ] },
         'A,C,E': { a: [ 'B,D,E' ], b: [ 'A,C,E' ] }
       }
-      const dfa1 = new NFA(dstart1, daccept1, dtable1)
+      const dfa = new NFA(dstart, daccept, dtable)
 
-      nfa1.determinize()
-      assert.deepStrictEqual(nfa1, dfa1)
-      assert(nfa1.isDeterministic())
+      nfa.determinize()
+      assert.deepStrictEqual(nfa, dfa)
+      assert(nfa.isDeterministic())
     })
 
     it('Should determinize NFA with epslon transitions', function () {
-      const start0 = '1'
-      const accept0 = [ '15' ]
-      const table0 = {
+      const start = '1'
+      const accept = [ '15' ]
+      const table = {
         '1': { '&': [ '2', '4' ] },
         '2': { 'b': [ '3' ] },
         '3': { '&': [ '6' ] },
@@ -387,94 +424,130 @@ describe('NFA', function () {
         '14': { '&': [ '8', '15' ] },
         '15': {}
       }
+      const nfa = new NFA(start, accept, table)
+      nfa.determinize()
 
-      const nfa0 = new NFA(start0, accept0, table0)
-      nfa0.determinize()
-
-      const expected0 = {
+      const expected = {
         '1': {
-          a: new Set([ '10,11,14,15,8,9' ]),
-          b: new Set([ '11,12,15,3,6,7,8,9' ])
+          a: [ '10,11,14,15,8,9' ],
+          b: [ '11,12,15,3,6,7,8,9' ],
+          c: []
         },
         '10,11,14,15,8,9': {
-          a: new Set([ '10,11,14,15,8,9' ]),
-          b: new Set([ '12' ])
+          a: [ '10,11,14,15,8,9' ],
+          b: [ '12' ],
+          c: []
         },
         '11,12,15,3,6,7,8,9': {
-          a: new Set([ '10,11,14,15,8,9' ]),
-          b: new Set([ '12' ]),
-          c: new Set([ '11,13,14,15,8,9' ])
+          a: [ '10,11,14,15,8,9' ],
+          b: [ '12' ],
+          c: [ '11,13,14,15,8,9' ]
         },
         '12': {
-          c: new Set([ '11,13,14,15,8,9' ])
+          a: [],
+          c: [ '11,13,14,15,8,9' ],
+          b: []
         },
         '11,13,14,15,8,9': {
-          a: new Set([ '10,11,14,15,8,9' ]),
-          b: new Set([ '12' ])
+          a: [ '10,11,14,15,8,9' ],
+          b: [ '12' ],
+          c: []
         }
       }
-      assert.deepStrictEqual(nfa0.table, expected0)
+      assert.deepStrictEqual(nfa.table, expected)
     })
   })
 
   describe('#match', function () {
-    it('Should match words that belongs to the language', function () {
-      // Fig. 1.7
-      // Introduction to the theory of computation
-      // Michael Sipser
-      // Empty string or ends in a zero
-      const start0 = 'q1'
-      const accept0 = [ 'q1' ]
-      const table0 = {
-        q1: { '1': [ 'q2' ], '0': [ 'q1' ] },
-        q2: { '1': [ 'q2' ], '0': [ 'q1' ] }
-      }
-      const nfa0 = new NFA(start0, accept0, table0)
+    // Fig. 1.7
+    // Introduction to the theory of computation
+    // Michael Sipser
+    // Empty string or ends in a zero
+    const start = 'q1'
+    const accept = [ 'q1' ]
+    const table = {
+      q1: { '1': [ 'q2' ], '0': [ 'q1' ] },
+      q2: { '1': [ 'q2' ], '0': [ 'q1' ] }
+    }
+    const nfa = new NFA(start, accept, table)
 
-      assert(nfa0.match('010'))
-      assert(nfa0.match('01010100001000'))
-      assert(nfa0.match('0'))
-      assert(nfa0.match(''))
-      assert(nfa0.match('1000010'))
-      assert(nfa0.match('10'))
+    const testMatchTrue = [
+      '010',
+      '01010100001000',
+      '0',
+      '',
+      '1000010',
+      '10'
+    ]
+    const testMatchFalse = [
+      '01',
+      '010011',
+      '11111',
+      '010100011'
+    ]
 
-      assert(!nfa0.match('01'))
-      assert(!nfa0.match('010011'))
-      assert(!nfa0.match('11111'))
-      assert(!nfa0.match('010100011'))
+    testMatchTrue.forEach(function (t) {
+      it('Should match words that belong to the language', function () {
+        assert(nfa.match(t))
+      })
+    })
 
-      // #0 >= 2 and ends with 0
-      const start1 = 'q0'
-      const accept1 = [ 'q2' ]
-      const table1 = {
-        q0: { '1': [ 'q0' ], '0': [ 'q1' ] },
-        q1: { '1': [ 'q1' ], '0': [ 'q2' ] },
-        q2: { '0': [ 'q2' ] }
-      }
-
-      const nfa1 = new NFA(start1, accept1, table1)
-
-      assert(nfa1.match('01000'))
-      assert(nfa1.match('0000'))
-      assert(nfa1.match('0100'))
-      assert(nfa1.match('00'))
-
-      assert(!nfa1.match('0'))
-      assert(!nfa1.match('10'))
-      assert(!nfa1.match('000001'))
-      assert(!nfa1.match('1111'))
-      assert(!nfa1.match(''))
+    testMatchFalse.forEach(function (t) {
+      it('Should not match words that do not belong to the language', function () {
+        assert(!nfa.match(t))
+      })
     })
   })
-  describe('#beautifyQn', () => {
-    it('should transform all original states into q0, q1, ..., qn', () => {
-      const start0 = 'S'
-      const accept0 = [ 'B' ]
-      const table0 = {
+
+  describe('#match', function () {
+    // #0 >= 2 and ends with 0
+    const start = 'q0'
+    const accept = [ 'q2' ]
+    const table = {
+      q0: { '1': [ 'q0' ], '0': [ 'q1' ] },
+      q1: { '1': [ 'q1' ], '0': [ 'q2' ] },
+      q2: { '0': [ 'q2' ] }
+    }
+    const nfa = new NFA(start, accept, table)
+
+    const testMatchTrue = [
+      '01000',
+      '0000',
+      '0100',
+      '00'
+    ]
+    const testMatchFalse = [
+      '0',
+      '10',
+      '000001',
+      '1111',
+      ''
+    ]
+
+    testMatchTrue.forEach(function (t) {
+      it('Should match words that belong to the language', function () {
+        assert(nfa.match(t))
+      })
+    })
+
+    testMatchFalse.forEach(function (t) {
+      it('Should not match words that do not belong to the language', function () {
+        assert(!nfa.match(t))
+      })
+    })
+  })
+
+  describe('#beautify', function () {
+    it('should transform all original states into q0, q1, ..., qn', function () {
+      const start = 'S'
+      const accept = [ 'B' ]
+      const table = {
         'S': { 'a': [ 'A' ] },
         'A': { 'b': [ 'B' ] },
         'B': {}
       }
+      const nfa = new NFA(start, accept, table)
+      nfa.beautify()
 
       const expectedStart = 'q0'
       const expectedAccept = [ 'q2' ]
@@ -483,49 +556,50 @@ describe('NFA', function () {
         'q1': { 'b': [ 'q2' ] },
         'q2': {}
       }
-      const nfa0 = new NFA(start0, accept0, table0)
-      nfa0.beautifyQn()
       const expected = new NFA(expectedStart, expectedAccept, expectedTable)
-      assert.deepStrictEqual(nfa0, expected)
+
+      assert.deepStrictEqual(nfa, expected)
     })
   })
-  describe('#union', () => {
-    it('should unite two FAs', () => {
+
+  describe('#union', function () {
+    it('should unite two FAs', function () {
       const start0 = 'S'
       const accept0 = [ 'B' ]
       const table0 = {
-        'S': { 'a': [ 'A' ] },
-        'A': { 'b': [ 'B' ] },
-        'B': {}
+        S: { a: [ 'A' ] },
+        A: { b: [ 'B' ] },
+        B: {}
       }
       const nfa0 = new NFA(start0, accept0, table0)
 
       const start1 = 'S'
       const accept1 = [ 'B' ]
       const table1 = {
-        'S': { 'a': [ 'A' ] },
-        'A': { 'c': [ 'B' ] },
-        'B': {}
+        S: { a: [ 'A' ] },
+        A: { c: [ 'B' ] },
+        B: {}
       }
       const nfa1 = new NFA(start1, accept1, table1)
 
-      const expectedStart = 'qinitial'
-      const expectedFinalStates = [ 'q2', 'q5' ]
-      const expectedTable = {
-        'q0': { 'a': [ 'q1' ] },
-        'q1': { 'b': [ 'q2' ] },
-        'q2': {},
-        'q3': { 'a': [ 'q4' ] },
-        'q4': { 'c': [ 'q5' ] },
-        'q5': {},
-        'qinitial': { 'a': [ 'q1', 'q4' ] }
+      const expStart = 'qinitial'
+      const expAccept = [ 'q2', 'q5' ]
+      const expTable = {
+        q0: { a: [ 'q1' ] },
+        q1: { b: [ 'q2' ] },
+        q2: {},
+        q3: { a: [ 'q4' ] },
+        q4: { c: [ 'q5' ] },
+        q5: {},
+        qinitial: { a: [ 'q1', 'q4' ] }
       }
+      const expected = new NFA(expStart, expAccept, expTable)
 
-      const nfa0UnionNfa1 = NFA.union(nfa0, nfa1)
-      assert
-        .deepStrictEqual(nfa0UnionNfa1, new NFA(expectedStart, expectedFinalStates, expectedTable))
+      const union = NFA.union(nfa0, nfa1)
+      assert.deepStrictEqual(union, expected)
     })
   })
+
   describe('#complete', () => {
     it('should complete the transitions of a incomplete automata', () => {
       const start = 'q0'
@@ -553,42 +627,44 @@ describe('NFA', function () {
       assert.deepStrictEqual(nfa1, expected)
     })
   })
-  describe('#concat', () => {
-    it('should concat two FAs', () => {
+
+  describe.only('#concat', function () {
+    it('should concat two FAs', function () {
       const start0 = 'S'
       const accept0 = [ 'B' ]
       const table0 = {
-        'S': { 'a': [ 'A' ] },
-        'A': { 'b': [ 'B' ] },
-        'B': {}
+        S: { a: [ 'A' ] },
+        A: { b: [ 'B' ] },
+        B: { c: [] }
       }
       const nfa0 = new NFA(start0, accept0, table0)
 
       const start1 = 'S'
       const accept1 = [ 'B' ]
       const table1 = {
-        'S': { 'a': [ 'A' ] },
-        'A': { 'c': [ 'B' ] },
-        'B': {}
+        S: { a: [ 'A' ] },
+        A: { c: [ 'B' ] },
+        B: { b: [] }
       }
       const nfa1 = new NFA(start1, accept1, table1)
 
-      const expectedStart = 'q0'
-      const expectedFinalStates = [ 'q5' ]
-      const expectedTable = {
-        'q0': { 'a': [ 'q1' ] },
-        'q1': { 'b': [ 'q2' ] },
-        'q2': { 'a': [ 'q4' ] },
-        'q3': { 'a': [ 'q4' ] },
-        'q4': { 'c': [ 'q5' ] },
-        'q5': {}
+      const expStart = 'q0'
+      const expAccept = [ 'q5' ]
+      const expTable = {
+        q0: { a: [ 'q1' ] },
+        q1: { b: [ 'q2' ] },
+        q2: { a: [ 'q4' ] },
+        q3: { a: [ 'q4' ] },
+        q4: { c: [ 'q5' ] },
+        q5: {}
       }
+      const expected = new NFA(expStart, expAccept, expTable)
 
-      const nfa0ConcatNfa1 = NFA.concat(nfa0, nfa1)
-      assert
-        .deepStrictEqual(nfa0ConcatNfa1, new NFA(expectedStart, expectedFinalStates, expectedTable))
+      const concat = NFA.concat(nfa0, nfa1)
+      assert.deepStrictEqual(concat, expected)
     })
   })
+
   describe('#star', () => {
     it('should star a FA', () => {
       const start0 = 'S'
@@ -613,6 +689,7 @@ describe('NFA', function () {
       assert.deepStrictEqual(nfa0Star, expected)
     })
   })
+
   describe('#reverse', () => {
     it('should reverse a already complete and deterministic FA', () => {
       const start0 = 'S'
@@ -660,6 +737,7 @@ describe('NFA', function () {
       assert.deepStrictEqual(NFA.reverse(nfa), expected)
     })
   })
+
   describe('#intersection', () => {
     it('should return the intersection of two FAs.', () => {
       const start0 = 'S'
@@ -695,6 +773,7 @@ describe('NFA', function () {
       assert.deepStrictEqual(intersection, expected)
     })
   })
+
   describe('#diff', () => {
     it('should get the diff between two AFs', () => {
       const start0 = 'S'
@@ -726,6 +805,7 @@ describe('NFA', function () {
       assert.deepStrictEqual(diff, expected)
     })
   })
+
   describe('#minimize', () => {
     it('should minimize a AF', () => {
       const start = 'A'

--- a/test/test_re.js
+++ b/test/test_re.js
@@ -15,11 +15,11 @@ describe('RE', function () {
 
   describe('#alphabet', function () {
     const testAlphabet = [
-      { input: '(ac1*|77*)', expected: new Set('ac177'.split('')) },
-      { input: '(ab|cd)?', expected: new Set('abcd'.split('')) },
-      { input: 'a*?a(a)|a', expected: new Set('a') },
-      { input: '( 1 | 2 | 3 )*', expected: new Set('123'.split('')) },
-      { input: '1|2*|( 7 )*', expected: new Set('127'.split('')) }
+      { input: '(ac1*|77*)', expected: 'ac17'.split('') },
+      { input: '(ab|cd)?', expected: 'abcd'.split('') },
+      { input: 'a*?a(a)|a', expected: 'a'.split('') },
+      { input: '( 1 | 2 | 3 )*', expected: '123'.split('') },
+      { input: '1|2*|( 7 )*', expected: '127'.split('') }
     ]
     testAlphabet.forEach(function (t) {
       it(`Should return the alphabet: ${Array.from(t.expected)}`, function () {
@@ -38,12 +38,12 @@ describe('RE', function () {
       const start = 'q0'
       const accept = [ 'q0', 'q1', 'q3', 'q5' ]
       const table = {
-        q0: { a: new Set([ 'q1' ]), b: new Set([ 'q2' ]) },
-        q1: { b: new Set([ 'q3' ]), c: new Set([ 'q3' ]) },
-        q2: { a: new Set([ 'q4' ]), c: new Set([ 'q5' ]) },
-        q3: { a: new Set([ 'q1' ]) },
-        q4: { c: new Set([ 'q5' ]) },
-        q5: { b: new Set([ 'q2' ]) }
+        q0: { a: [ 'q1' ], b: [ 'q2' ] },
+        q1: { b: [ 'q3' ], c: [ 'q3' ] },
+        q2: { a: [ 'q4' ], c: [ 'q5' ] },
+        q3: { a: [ 'q1' ] },
+        q4: { c: [ 'q5' ] },
+        q5: { b: [ 'q2' ] }
       }
       const expected = new NFA(start, accept, table)
       const result = re.toDFA()
@@ -59,10 +59,10 @@ describe('RE', function () {
       const start = 'q0'
       const accept = [ 'q1', 'q2' ]
       const table = {
-        q0: { a: new Set([ 'q2' ]), b: new Set([ 'q1' ]) },
-        q1: { a: new Set([ 'q0' ]) },
-        q2: { a: new Set([ 'q0' ]), b: new Set([ 'q3' ]) },
-        q3: { a: new Set([ 'q2' ]) }
+        q0: { a: [ 'q2' ], b: [ 'q1' ] },
+        q1: { a: [ 'q0' ] },
+        q2: { a: [ 'q0' ], b: [ 'q3' ] },
+        q3: { a: [ 'q2' ] }
       }
       const expected = new NFA(start, accept, table)
       const result = re.toDFA()


### PR DESCRIPTION
List of modifications:

- Now all hte methods return arrays instead of sets;
- Refactored the code, and tests, to be more concise (where I could);


Future modifications (?):
- Add a call to `beautify` at the end of each function that alters the automata? Then it would be always the same style. No matter the operation.
