### PR TITLE
Fixed bug in the Simone algorithm.

### DIFF
--- a/src/re.js
+++ b/src/re.js
@@ -3,6 +3,7 @@ const NFA = require('../src/nfa')
 const VALID_INPUT = /^[\s/|/?/*/.A-Z0-9/(/)]*$/ig
 const ALPHABET = /[A-Z0-9]/i
 const WHITE_SPACE = /\s/gi
+const OPERATORS = /[*|?.]/gi
 
 class RE {
   constructor (reString) {
@@ -180,14 +181,14 @@ class Simone {
 
   down (node) {
     const result = this._down(node)
-    const copy = Array.from(result)
+    const copy = Array.from(result).filter(i => !i.value.match(OPERATORS))
     this.visited.clear()
     return new Set(copy)
   }
 
   up (node) {
     const result = this._up(node)
-    const copy = Array.from(result)
+    const copy = Array.from(result).filter(i => !i.value.match(OPERATORS))
     this.visited.clear()
     return new Set(copy)
   }
@@ -196,6 +197,13 @@ class Simone {
     const right = node.right
     const left = node.left
     const value = node.value
+
+    // Avoid infinite recursions with **
+    if (this.visited.has(node)) {
+      return this.visited
+    }
+
+    this.visited.add(node)
 
     switch (value) {
       case '|':
@@ -211,7 +219,7 @@ class Simone {
         this._down(left)
         break
       default:
-        this.visited.add(node)
+        // Does nothing
         break
     }
 

--- a/test/test_nfa.js
+++ b/test/test_nfa.js
@@ -824,7 +824,7 @@ describe('NFA', function () {
   })
 
   describe('#intersection', function () {
-    it('should return the intersection of two FAs.', function () {
+    it('Should return the intersection of two FAs.', function () {
       const start0 = 'S'
       const accept0 = [ 'S', 'A' ]
       const table0 = {
@@ -994,6 +994,34 @@ describe('NFA', function () {
       const expected = new NFA(expStart, expAccept, expTable)
 
       nfa.minimize()
+      assert.deepStrictEqual(nfa, expected)
+    })
+
+    it('Should minimize simple AF', function () {
+      const start = 'q0'
+      const accept = [ 'q5' ]
+      const table = {
+        q0: { a: [ 'q1' ] },
+        q1: { b: [ 'q2' ] },
+        q2: { b: [ 'q4' ] },
+        q3: { b: [ 'q4' ] },
+        q4: { a: [ 'q5' ] },
+        q5: {}
+      }
+      const nfa = new NFA(start, accept, table)
+      nfa.minimize()
+
+      const expStart = 'q0'
+      const expAccept = [ 'q4' ]
+      const expTable = {
+        q0: { a: [ 'q1' ] },
+        q1: { b: [ 'q2' ] },
+        q2: { b: [ 'q3' ] },
+        q3: { a: [ 'q4' ] },
+        q4: {}
+      }
+      const expected = new NFA(expStart, expAccept, expTable)
+
       assert.deepStrictEqual(nfa, expected)
     })
   })

--- a/test/test_parser.js
+++ b/test/test_parser.js
@@ -112,5 +112,27 @@ describe('Parser', function () {
 
       assert.deepStrictEqual(parser.regex(), expected)
     })
+
+    it('Should parse regular expression with **', function () {
+      const regex = 'a**'
+      const parser = new Parser(regex)
+
+      const result = parser.regex()
+      const expected = {
+        value: '*',
+        left: {
+          value: '*',
+          left: {
+            value: 'a',
+            left: null,
+            right: null
+          },
+          right: null
+        },
+        right: null
+      }
+
+      assert.deepStrictEqual(result, expected)
+    })
   })
 })

--- a/test/test_re.js
+++ b/test/test_re.js
@@ -30,7 +30,7 @@ describe('RE', function () {
   })
 
   describe('#toDFA', function () {
-    it('Converts to DFA (1)', function () {
+    it('Converts to DFA', function () {
       const regex = '(ab|ac)*a?|(ba?c)*'
       const re = new RE(regex)
 
@@ -51,7 +51,7 @@ describe('RE', function () {
       assert.deepStrictEqual(result, expected)
     })
 
-    it('Converts to DFA (2)', function () {
+    it('Converts to DFA', function () {
       const regex = '(ba|a(ba)*a)*(b|a(ba)*)'
       const re = new RE(regex)
 
@@ -67,6 +67,41 @@ describe('RE', function () {
       const expected = new NFA(start, accept, table)
       const result = re.toDFA()
       assert.deepStrictEqual(result, expected)
+    })
+
+    it('Converts to DFA', function () {
+      const regex = '(ab*)*'
+      const re = new RE(regex)
+
+      const start = 'q0'
+      const accept = [ 'q0', 'q1' ]
+      const table = {
+        q0: { a: [ 'q1' ] },
+        q1: { a: [ 'q1' ], b: [ 'q1' ] }
+      }
+      const expected = new NFA(start, accept, table)
+      const result = re.toDFA()
+      assert.deepStrictEqual(result, expected)
+    })
+
+    const starTest = [ 2, 3, 4, 5, 6, 7, 8, 9 ]
+    starTest.forEach(function (starNum) {
+      const input = 'a'.padEnd(1 + starNum, '*')
+      it(`Should convert regex with any number of * (${input})`, function () {
+        const re = new RE(input)
+        const nfa = re.toDFA()
+        nfa.minimize()
+        nfa.beautify()
+
+        const start = 'q0'
+        const accept = [ 'q0' ]
+        const table = {
+          q0: { a: [ 'q0' ] }
+        }
+        const expected = new NFA(start, accept, table)
+
+        assert.deepStrictEqual(nfa, expected)
+      })
     })
   })
 })


### PR DESCRIPTION
- The algorithm would enter an infinite loop when going on regex with '**'.
- Now, it does not. It saves all nodes that it goes and filter the ones
we do not want when returning the values.