### PR TITLE
Modified Union function

### DIFF
--- a/src/nfa.js
+++ b/src/nfa.js
@@ -822,13 +822,19 @@ class NFA {
     const start2 = fa2.table[fa2.start]
 
     // Merge states
-    const entries = Object.entries(start1)
-    for (const [symbol, states] of entries) {
-      // We can do this concatenation here because it is assumed the NFAs
-      // have the same alphabet. And, all transitions have, at least, an
-      // empty array in it's place
-      const newStates = states.concat(start2[symbol])
-      newTable[newStart][symbol] = newStates
+    const visitedTransitions = new Set()
+    const entries1 = Object.entries(start1)
+    for (const [symbol, states] of entries1) {
+      newTable[newStart][symbol] = [...states]
+      visitedTransitions.add(symbol)
+    }
+    const entries2 = Object.entries(start2)
+    for (const [symbol, states] of entries2) {
+      if (visitedTransitions.has(symbol)) {
+        newTable[newStart][symbol].push(...states)
+      } else {
+        newTable[newStart][symbol] = [...states]
+      }
     }
 
     // Adds newStart to final states if previous start was a accept state

--- a/test/test_nfa.js
+++ b/test/test_nfa.js
@@ -652,7 +652,7 @@ describe('NFA', function () {
       const table0 = {
         S: { a: [ 'A' ] },
         A: { b: [ 'B' ] },
-        B: { c: [] }
+        B: { }
       }
       const nfa0 = new NFA(start0, accept0, table0)
 
@@ -661,7 +661,7 @@ describe('NFA', function () {
       const table1 = {
         S: { a: [ 'A' ] },
         A: { c: [ 'B' ] },
-        B: { b: [] }
+        B: { }
       }
       const nfa1 = new NFA(start1, accept1, table1)
 


### PR DESCRIPTION
  - Previous version assumed both automatas had same alphabet. This
    version improves this function by not assuming this statement thus
    making it work with all cases.