### PR TITLE
Enumerate

### DIFF
--- a/src/grammar.js
+++ b/src/grammar.js
@@ -41,13 +41,13 @@ class Grammar {
       const newSet = new Set(Array.from(sentences))
 
       for (const sentence of sentences) {
-        const length = sentence.length
-        const last = sentence[length - 1]
-        if (!last.match(/[A-Z]/)) {
+        const match = sentence.match(/^([a-z]*)([A-Z]'?)$/)
+        if (match === null) {
           continue
         }
 
-        const substring = sentence.substring(0, length - 1)
+        const last = match[2]
+        const substring = match[1]
         const productions = this.productions[last]
         for (const production of productions) {
           if (production === '&') {

--- a/src/grammar.js
+++ b/src/grammar.js
@@ -28,6 +28,56 @@ class Grammar {
   }
 
   /**
+   * Return the possible senteces that this grammar can generate.
+   *
+   * @param  {Number} num Size limit of the sentences to be generated.
+   *
+   * @return {Array}      Array with all the generated sentences.
+   */
+  enumerate (num) {
+    const sentences = new Set([ this.first ])
+
+    while (true) {
+      const newSet = new Set(Array.from(sentences))
+
+      for (const sentence of sentences) {
+        const length = sentence.length
+        const last = sentence[length - 1]
+        if (!last.match(/[A-Z]/)) {
+          continue
+        }
+
+        const substring = sentence.substring(0, length - 1)
+        const productions = this.productions[last]
+        for (const production of productions) {
+          if (production === '&') {
+            newSet.add('&')
+            continue
+          }
+
+          const newSentence = substring + production
+          if (newSentence.length <= num) {
+            newSet.add(newSentence)
+          }
+        }
+      }
+
+      // No change
+      if (newSet.size === sentences.size) {
+        break
+      }
+
+      // Union of sets
+      newSet.forEach(i => sentences.add(i))
+    }
+
+    return Array
+      .from(sentences)
+      .filter(i => i.match(/^([a-z\d]*|&)$/g))
+      .sort()
+  }
+
+  /**
    * Generates a grammar from a non-deterministic finite automaton.
    *
    * @param {NFA} nfa

--- a/src/nfa.js
+++ b/src/nfa.js
@@ -154,8 +154,10 @@ class NFA {
       return
     }
 
-    this.accept.push(name)
-    this.accept.sort()
+    if (!this.accept.includes(name)) {
+      this.accept.push(name)
+      this.accept.sort()
+    }
   }
 
   removeAccept (name) {

--- a/test/test_grammar.js
+++ b/test/test_grammar.js
@@ -45,6 +45,7 @@ describe('Grammar', function () {
       assert.deepStrictEqual(result, expected)
     })
   })
+
   describe('#union', function () {
     it('Should unite two grammars', function () {
       const start1 = 'S'
@@ -70,6 +71,7 @@ describe('Grammar', function () {
       assert.deepStrictEqual(union, expected)
     })
   })
+
   describe('#concat', function () {
     it('Should concat two grammars', function () {
       const start1 = 'S'
@@ -95,6 +97,7 @@ describe('Grammar', function () {
       assert.deepStrictEqual(concat, expected)
     })
   })
+
   describe('#closure', function () {
     it("The closure of a even number of a's grammar is the same grammar", function () {
       const start = "S'"
@@ -125,6 +128,7 @@ describe('Grammar', function () {
       assert.deepStrictEqual(closure, expected)
     })
   })
+
   describe('#intersection', function () {
     it('Should intersect two grammars', function () {
       const start1 = 'S'
@@ -149,6 +153,7 @@ describe('Grammar', function () {
       assert.deepStrictEqual(intersection, expected)
     })
   })
+
   describe('#diff', function () {
     it('Should get the difference between two grammars', function () {
       const start1 = 'S'
@@ -184,6 +189,7 @@ describe('Grammar', function () {
       assert.deepStrictEqual(diff, expected)
     })
   })
+
   describe('#reverse', function () {
     it('Should reverse a grammar', function () {
       const start = 'S'
@@ -204,6 +210,78 @@ describe('Grammar', function () {
       }
       const expected = new Grammar(expStart, expProductions)
       assert.deepStrictEqual(reverse, expected)
+    })
+  })
+
+  describe('#enumerate', function () {
+    it('Should return all sentences up to a number', function () {
+      const first = 'S'
+      const productions = {
+        S: [ 'a', 'aS' ]
+      }
+      const grammar = new Grammar(first, productions)
+
+      const result = grammar.enumerate(5)
+      const expected = [ 'a', 'aa', 'aaa', 'aaaa', 'aaaaa' ]
+      assert.deepStrictEqual(result, expected)
+    })
+
+    it('Should return all sentences up to a number', function () {
+      const first = 'S'
+      const productions = {
+        S: [ 'aA' ],
+        A: [ 'b' ]
+      }
+      const grammar = new Grammar(first, productions)
+
+      const result = grammar.enumerate(5)
+      const expected = [ 'ab' ]
+      assert.deepStrictEqual(result, expected)
+    })
+
+    it('Should return all sentences up to a number', function () {
+      const first = 'S'
+      const productions = {
+        // Starts with a and has even #b following
+        // or
+        // Starts with b and has odd #a following
+        S: [ 'aA', 'bC', 'a' ],
+        A: [ 'bB' ],
+        B: [ 'bA', 'b' ],
+        C: [ 'aD', 'a' ],
+        D: [ 'aC' ]
+      }
+      const grammar = new Grammar(first, productions)
+
+      const result = grammar.enumerate(5)
+      const expected = [ 'a', 'abb', 'abbbb', 'ba', 'baaa' ].sort()
+      assert.deepStrictEqual(result, expected)
+    })
+
+    it('Should return all sentences up to a number, with epslon', function () {
+      const first = 'S'
+      const productions = {
+        S: [ 'aA', '&' ],
+        A: [ 'b' ]
+      }
+      const grammar = new Grammar(first, productions)
+
+      const result = grammar.enumerate(5)
+      const expected = [ '&', 'ab' ]
+      assert.deepStrictEqual(result, expected)
+    })
+
+    it('Should return empty to a non productive grammar', function () {
+      const first = 'S'
+      const productions = {
+        S: [ 'aA' ],
+        A: [ 'bS' ]
+      }
+      const grammar = new Grammar(first, productions)
+
+      const result = grammar.enumerate(5)
+      const expected = []
+      assert.deepStrictEqual(result, expected)
     })
   })
 })

--- a/test/test_grammar.js
+++ b/test/test_grammar.js
@@ -259,9 +259,9 @@ describe('Grammar', function () {
     })
 
     it('Should return all sentences up to a number, with epslon', function () {
-      const first = 'S'
+      const first = "S'"
       const productions = {
-        S: [ 'aA', '&' ],
+        "S'": [ 'aA', '&' ],
         A: [ 'b' ]
       }
       const grammar = new Grammar(first, productions)
@@ -272,10 +272,10 @@ describe('Grammar', function () {
     })
 
     it('Should return empty to a non productive grammar', function () {
-      const first = 'S'
+      const first = "S'"
       const productions = {
-        S: [ 'aA' ],
-        A: [ 'bS' ]
+        "S'": [ 'aA' ],
+        A: [ "bS'" ]
       }
       const grammar = new Grammar(first, productions)
 

--- a/test/test_nfa.js
+++ b/test/test_nfa.js
@@ -917,6 +917,72 @@ describe('NFA', function () {
       nfa.removeState('B')
       assert.deepStrictEqual(nfa, expected)
     })
+
+    it('Should do nothin when trying to remove inexistent state', function () {
+      const start = 'A'
+      const accept = [ 'A', 'B' ]
+      const table = {
+        A: { a: [ 'B' ], b: [ 'A' ] },
+        B: { a: [ 'C' ], b: [ 'A' ] },
+        C: { b: [ 'A' ] }
+      }
+      const nfa = new NFA(start, accept, table)
+      const expected = new NFA(start, accept, table)
+      nfa.removeState('D')
+      nfa.removeState('E')
+
+      assert.deepStrictEqual(nfa, expected)
+    })
+  })
+
+  describe('#removeAccept', function () {
+    const start = 'S'
+    const accept = [ 'A,C', 'C' ]
+    const table = {
+      'S': { a: [ 'A,B' ] },
+      'A,B': { a: [ 'A,C' ], b: [ 'B' ] },
+      'A,C': { a: [ 'A,C' ] },
+      'B': { a: [ 'C' ], b: [ 'B' ] },
+      'C': {}
+    }
+    const nfa = new NFA(start, accept, table)
+
+    it('Should do nothin when trying to remove inexistent state', function () {
+      nfa.removeAccept('A')
+      const expected = [ 'A,C', 'C' ]
+      assert.deepStrictEqual(nfa.accept, expected)
+    })
+
+    it('Should remove from accept', function () {
+      nfa.removeAccept('C')
+      const expected = [ 'A,C' ]
+      assert.deepStrictEqual(nfa.accept, expected)
+    })
+  })
+
+  describe('#addAccept', function () {
+    const start = 'S'
+    const accept = [ 'A,C', 'C' ]
+    const table = {
+      'S': { a: [ 'A,B' ] },
+      'A,B': { a: [ 'A,C' ], b: [ 'B' ] },
+      'A,C': { a: [ 'A,C' ] },
+      'B': { a: [ 'C' ], b: [ 'B' ] },
+      'C': {}
+    }
+    const nfa = new NFA(start, accept, table)
+
+    it('Should do nothin when trying to add inexistent state', function () {
+      nfa.addAccept('A')
+      const expected = [ 'A,C', 'C' ].sort()
+      assert.deepStrictEqual(nfa.accept, expected)
+    })
+
+    it('Should add to accept', function () {
+      nfa.addAccept('S')
+      const expected = [ 'A,C', 'C', 'S' ].sort()
+      assert.deepStrictEqual(nfa.accept, expected)
+    })
   })
 
   describe('#removeUnreachable', function () {


### PR DESCRIPTION
Fixed a bug related to productions with ' symbol in it.

Example:
```
S' -> aS' | a
```